### PR TITLE
Fixed formatting

### DIFF
--- a/docs/msk-data-gen-container-deploy.md
+++ b/docs/msk-data-gen-container-deploy.md
@@ -143,9 +143,9 @@ Here's a walk-through example of one way to get started
     we should see events such as
 
     ```
-{"quantity":"2","product_id":"114","customer_id":"e45bb3bb-35e7-4314-90e7-e0adf8df8c57"}
-{"quantity":"2","product_id":"140","customer_id":"b78a7812-32fb-40c0-b028-f2111589fc61"}
-```
+    {"quantity":"2","product_id":"114","customer_id":"e45bb3bb-35e7-4314-90e7-e0adf8df8c57"}
+    {"quantity":"2","product_id":"140","customer_id":"b78a7812-32fb-40c0-b028-f2111589fc61"}
+    ```
 
     Nice.  We see two events in the example above.  
 


### PR DESCRIPTION
A spacing error in the formating for the <pre> block was ruining t he formatting for the remainder of the page

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
